### PR TITLE
fixed issue of `removeFore` returning null

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
             <div class="row">
               <div id="first-card" class="col">
                 <div class="card mx-auto">
-                  <div class="current">Currently</div>
+                  <div class="current">Today</div>
                   <div class="description card-subtitle"></div>
                   <div class="pics">
                     <img src="https://openweathermap.org/img/wn/04n.png" alt="weather icon" class="icon card-img-top" />
@@ -108,6 +108,7 @@
                     <div class="sunset card-text"></div>
                   </div>
                 </div>
+                <div class="forecast-day row"></div>
               </div>
             </div>
           </div>

--- a/script.js
+++ b/script.js
@@ -191,8 +191,6 @@ function foreDays(flat, flon, num) {
   Foreatherweek.fetchWeather(flat, flon, num);
 }
 
-
-
 //onclick to the button get the value user input, then call forecast function to display "Xiaodong Huang"
 function threedis() {
   foreDays(flat, flon, document.getElementById("threeDay").value);
@@ -202,7 +200,7 @@ function sevendis() {
   foreDays(flat, flon, document.getElementById("sevenDay").value);
 }
 
-//clear the forecast 
+// // clear the forecast 
 function removefore() {
   var removeForecast = document.querySelector(".forecast-day");
   while (removeForecast.children.length > 0) {
@@ -210,9 +208,8 @@ function removefore() {
   }
 }
 
-//clear the forecast  
+// //clear the forecast  
 function clearfore() {
-
   var removeForecast = document.querySelector(".forecast-day");
   while (removeForecast.children.length > 0) {
     removeForecast.removeChild(removeForecast.lastChild);
@@ -279,7 +276,7 @@ function foreDisplay(data, num) {
           <div class="sunset card-text">Sunset ${sunsetTime(value.sunset)}</div>
         </div>
       </div>`;
-      firstCard.insertAdjacentHTML('beforeend', fday);
+      forecast[0].insertAdjacentHTML('beforeend', fday);
     }
   });
 }


### PR DESCRIPTION
 - Fixed issue of `removeFore` returning null when trying to call 3-day, 7-day, and clear forecast options. 